### PR TITLE
Allow unknown product keys for product details

### DIFF
--- a/src/ecommerce.ts
+++ b/src/ecommerce.ts
@@ -16,24 +16,6 @@ const EVENTS: { [k: string]: string } = {
   'Order Refunded': 'refund',
 }
 
-const PRODUCT_DETAILS: string[] = [
-  'cart_id',
-  'product_id',
-  'sku',
-  'category',
-  'name',
-  'brand',
-  'variant',
-  'price',
-  'quantity',
-  'coupon',
-  'position',
-
-  'affiliation',
-  'discount',
-  'currency',
-]
-
 // list of params that will be prefixed in the request with
 // ep for string values
 // epn for numbers
@@ -117,15 +99,4 @@ const buildProductRequest = (item: { [k: string]: any }) => {
   return resultList.join('~')
 }
 
-// product comes in standard format
-// returns GA4's standard item
-const mapProductToItem = (product: any) => {
-  const eventProductDescription = PRODUCT_DETAILS
-  const item: any = {}
-  for (const prop of eventProductDescription) {
-    product[prop] && (item[prop] = product[prop])
-  }
-  return item
-}
-
-export { EVENTS, mapProductToItem, PREFIX_PARAMS_MAPPING, buildProductRequest }
+export { EVENTS, PREFIX_PARAMS_MAPPING, buildProductRequest }

--- a/src/requestBuilder.ts
+++ b/src/requestBuilder.ts
@@ -2,7 +2,6 @@ import { ComponentSettings, MCEvent } from '@managed-components/types'
 import {
   buildProductRequest,
   EVENTS,
-  mapProductToItem,
   PREFIX_PARAMS_MAPPING,
 } from './ecommerce'
 import { flattenKeys, isNumber } from './utils'
@@ -169,14 +168,12 @@ const getFinalURL = (
     if (ecommerceData.products) {
       // handle products list
       for (const [index, product] of (ecommerceData.products || []).entries()) {
-        const item = mapProductToItem(product)
-        prQueryParams = buildProductRequest(item)
+        prQueryParams = buildProductRequest(product)
         toolRequest[`pr${index + 1}`] = prQueryParams
       }
     } else {
       // handle single product data
-      const item = mapProductToItem(ecommerceData)
-      prQueryParams = buildProductRequest(item)
+      prQueryParams = buildProductRequest(ecommerceData)
       if (prQueryParams) toolRequest['pr1'] = prQueryParams
     }
   }


### PR DESCRIPTION
Adds additional item parameter mappings for GA4 ecommerce including category2-5, which fixes #3.

Parameters from: https://www.thyngster.com/ga4-measurement-protocol-cheatsheet/