### PR TITLE
Remove debug_mode key if falsy or 'false'

### DIFF
--- a/src/requestBuilder.ts
+++ b/src/requestBuilder.ts
@@ -208,6 +208,12 @@ const getFinalURL = (
 
   toolRequest = { ...toolRequest, ...partialToolRequest }
 
+  // Presence of `debug_mode` key will still enable debug mode.
+  // Removing the key allows conditionally disabling debug_mode.
+  if (!toolRequest['ep.debug_mode'] || toolRequest['ep.debug_mode'] === 'false') {
+    delete toolRequest['ep.debug_mode']
+  }
+
   const queryParams = new URLSearchParams(toolRequest).toString()
 
   const baseURL = 'https://www.google-analytics.com/g/collect?'


### PR DESCRIPTION
Allows `debug_mode` key to be set conditionally, e.g. via JSONata:
```
{{ system.page.url.hostname != 'www.example.com' }}
```

Without this change, `debug_mode` can't be enabled or disabled conditionally because GA4 will enable debug mode based on the presence of the `debug_mode` key, regardless of the value, or even if it's empty.

See [GA4 docs](https://support.google.com/analytics/answer/7201382) for more info.

The idea behind this change was suggested by @bjesus [in Discord](https://discord.com/channels/595317990191398933/917505178016579605/1155594396180414504).