### PR TITLE
engagement time: only send the parameter if non-zero

### DIFF
--- a/src/requestBuilder.ts
+++ b/src/requestBuilder.ts
@@ -92,7 +92,7 @@ function getToolRequest(
   requestBody['cid'] = cid
 
   //const notTheFirstSession = parseInt(requestBody['_s'] as string) > 1
-  const engagementDuration = client.get('engagementDuration')
+  const engagementDuration = parseInt(String(client.get('engagementDuration')), 10) || 0;
   if (engagementDuration) {
     requestBody._et = engagementDuration
   }


### PR DESCRIPTION
Following our discussion with David, the engagement time parameter happens to be sent with a zero value: There was a check in the code not to send it if 0, but it was wrong (boolean check on string equal to '0' instead of number).

The rationale is that if GA4 averages the engagement_time by the number of times the parameter was received, numerous instances of 0 decrease the total. 

Thanks!

